### PR TITLE
[@dhealthdapps/backend] refactor(common): fix todo tasks for NetworkService in common scope

### DIFF
--- a/runtime/backend/config/network.ts
+++ b/runtime/backend/config/network.ts
@@ -40,10 +40,16 @@ export default () => ({
    * Note that it is OK to use IP addresses rather than a domain
    * name in this configuration option.
    *
-   * @example `"http://dual-02.dhealth.cloud:3000"`
+   * @example `{
+   *    url: "http://dual-02.dhealth.cloud:3000",
+   *    publicKey: "613010BCE1FBF3CE1503DEF3003C76E451EA4DD9205FAD3530BFF7B1D78BC989"
+   * }`
    * @var {string}
    */
-  defaultNode: "http://dual-02.dhealth.cloud:3000",
+  defaultNode: {
+    url: "http://dual-02.dhealth.cloud:3000",
+    publicKey: "613010BCE1FBF3CE1503DEF3003C76E451EA4DD9205FAD3530BFF7B1D78BC989"
+  },
 
   /**
    * A list of operating network nodes that can be connected to.

--- a/runtime/backend/src/common/concerns/DappHelper.ts
+++ b/runtime/backend/src/common/concerns/DappHelper.ts
@@ -1,0 +1,64 @@
+/**
+ * This file is part of dHealth dApps Framework shared under LGPL-3.0
+ * Copyright (C) 2022-present dHealth Network, All rights reserved.
+ *
+ * @package     dHealth dApps Framework
+ * @subpackage  Backend
+ * @author      dHealth Network <devs@dhealth.foundation>
+ * @license     LGPL-3.0
+ */
+// external dependencies
+import { BlockHttp, UInt64 } from "@dhealth/sdk";
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { NetworkService } from "../services";
+
+@Injectable()
+export class DappHelper {
+  /**
+   * Constructs an instance of this helper.
+   *
+   * @constructor
+   * @param {ConfigService} configService
+   */
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly networkService: NetworkService,
+  ) {}
+
+  /**
+   * Method to get timestamp from a dHealth block-height number.
+   *
+   * @async
+   * @access public
+   * @param {BlockHttp} blockRepository
+   * @param {number} height
+   * @returns {Promise<number>}
+   */
+  public async getBlockTimestamp(
+    blockRepository: BlockHttp,
+    height: number,
+  ): Promise<number> {
+    const [block] = await this.networkService.delegatePromises([
+      blockRepository.getBlockByHeight(UInt64.fromUint(height)).toPromise(),
+    ]);
+    if (!block) throw new Error("Cannot query block from height");
+    const timestamp = this.getNetworkTimestampFromUInt64(block.timestamp);
+    return timestamp * 1000;
+  }
+
+  /**
+   * Method to get (network adjusted) timestamp from an UInt64 timestamp.
+   *
+   * @access public
+   * @param {UInt64} timestamp
+   * @returns {number}
+   */
+  public getNetworkTimestampFromUInt64(timestamp: UInt64): number {
+    const timestampNumber = timestamp.compact();
+    const epochAdjustment = this.configService.get<number>(
+      "network.epochAdjustment",
+    );
+    return Math.round(timestampNumber / 1000) + epochAdjustment;
+  }
+}

--- a/runtime/backend/src/common/concerns/index.ts
+++ b/runtime/backend/src/common/concerns/index.ts
@@ -14,3 +14,4 @@ export * from "./Pageable";
 export * from "./Queryable";
 export * from "./Sortable";
 export * from "./Transferable";
+export * from "./DappHelper";

--- a/runtime/backend/src/common/models/NetworkConfig.ts
+++ b/runtime/backend/src/common/models/NetworkConfig.ts
@@ -9,6 +9,29 @@
  */
 /**
  * @label COMMON
+ * @type DefaultNodePayload
+ * @description This type consists of an URL anda publicKey that are used
+ * to establish the connection and query info of the default node.
+ * <br /><br />
+ * @example Using the `DefaultNodePayload` type to configure nodes
+ * ```ts
+ *  // by default the URL can contain the schema and port
+ *  const defaultNode = {
+ *    url: "http://dual-02.dhealth.cloud:3000",
+ *    publicKey: "613010BCE1FBF3CE1503DEF3003C76E451EA4DD9205FAD3530BFF7B1D78BC989"
+ *  } as DefaultNodePayload;
+ * ```
+ *
+ * @link NetworkConfig:COMMON
+ * @since v0.3.0
+ */
+export type DefaultNodePayload = {
+  url: string;
+  publicKey: string;
+};
+
+/**
+ * @label COMMON
  * @type NodeConnectionPayload
  * @description This type consists of an URL and an optional port
  * that are used to establish the connection with an operating
@@ -82,18 +105,19 @@ export type NetworkParameters = {
  */
 export interface NetworkConfig {
   /**
-   * A default operation network node to connect to. This must be
-   * a URL that contains a schema and a port, which identifies the
-   * node and where it is operating.
+   * A default operation network node to connect to.
+   * This configuration option uses the {@link DefaultNodePayload:COMMON}
+   * type and consists of an URL and a publicKey that are used
+   * to establish the connection and query info of the default node.
    * <br /><br />
    * Note that it is OK to use IP addresses rather than a domain
    * name in this configuration option.
    *
    * @example `"http://dual-02.dhealth.cloud:3000"`
    * @access public
-   * @var {string}
+   * @var {DefaultNodePayload}
    */
-  defaultNode: string;
+  defaultNode: DefaultNodePayload;
 
   /**
    * A list of operating network nodes that can be connected to.

--- a/runtime/backend/src/common/modules/HelpersModule.ts
+++ b/runtime/backend/src/common/modules/HelpersModule.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of dHealth dApps Framework shared under LGPL-3.0
+ * Copyright (C) 2022-present dHealth Network, All rights reserved.
+ *
+ * @package     dHealth dApps Framework
+ * @subpackage  Backend
+ * @author      dHealth Network <devs@dhealth.foundation>
+ * @license     LGPL-3.0
+ */
+// external dependencies
+import { Module } from "@nestjs/common";
+
+// internal dependencies
+import { DappHelper } from "../concerns/DappHelper";
+
+/**
+ * @class HelpersModule
+ * @description The main definition for the Network module.
+ *
+ * @since v0.1.0
+ */
+@Module({
+  providers: [DappHelper],
+  exports: [DappHelper],
+})
+export class HelpersModule {}

--- a/runtime/backend/tests/unit/common/concerns/DappHelper.spec.ts
+++ b/runtime/backend/tests/unit/common/concerns/DappHelper.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * This file is part of dHealth dApps Framework shared under LGPL-3.0
+ * Copyright (C) 2022-present dHealth Network, All rights reserved.
+ *
+ * @package     dHealth dApps Framework
+ * @subpackage  Backend
+ * @author      dHealth Network <devs@dhealth.foundation>
+ * @license     LGPL-3.0
+ */
+// external dependencies
+import { BlockHttp } from "@dhealth/sdk";
+import { ConfigService } from "@nestjs/config";
+import { Test, TestingModule } from "@nestjs/testing";
+
+// internal dependencies
+import { DappHelper } from "../../../../src/common/concerns/DappHelper";
+import { NetworkService } from "../../../../src/common/services/NetworkService";
+
+describe("common/QueryService", () => {
+  let service: DappHelper;
+  let configService: ConfigService;
+
+  let mockDate: Date;
+  beforeEach(async () => {
+    mockDate = new Date(1212, 1, 1);
+    jest.useFakeTimers("modern");
+    jest.setSystemTime(mockDate);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DappHelper, ConfigService, NetworkService],
+    }).compile();
+
+    service = module.get<DappHelper>(DappHelper);
+    configService = module.get<ConfigService>(ConfigService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("getBlockTimestamp() -->", () => {
+    it("should have correct flow and result when response is not empty", async () => {
+      const getBlockByHeightCall = jest.fn(() => ({
+        toPromise: () => Promise.resolve({}),
+      }));
+      const blockRepository: BlockHttp = {
+        getBlockByHeight: getBlockByHeightCall,
+      } as any;
+      const getNetworkTimestampFromUInt64Call = jest
+        .spyOn(service, "getNetworkTimestampFromUInt64")
+        .mockReturnValue(1);
+      const result = await service.getBlockTimestamp(blockRepository, 1);
+      expect(getBlockByHeightCall).toBeCalled();
+      expect(getNetworkTimestampFromUInt64Call).toBeCalled();
+      expect(result).toEqual(1000);
+    });
+
+    it("should throw correct error when response is empty", async () => {
+      const getBlockByHeightCall = jest.fn(() => ({
+        toPromise: () => Promise.resolve(),
+      }));
+      const blockRepository: BlockHttp = {
+        getBlockByHeight: getBlockByHeightCall,
+      } as any;
+      const getNetworkTimestampFromUInt64Call = jest
+        .spyOn(service, "getNetworkTimestampFromUInt64")
+        .mockReturnValue(1);
+      await service.getBlockTimestamp(blockRepository, 1).catch((err: Error) => {
+        expect(getBlockByHeightCall).toBeCalled();
+        expect(getNetworkTimestampFromUInt64Call).toBeCalledTimes(0);
+        expect(err.message).toEqual("Cannot query block from height");
+      });
+    });
+  });
+
+  describe("getNetworkTimestampFromUInt64() -->", () => {
+    it("should have correct flow and result", () => {
+      const timestamp = { compact: () => 1000 };
+      const configGetCall = jest.spyOn(configService, "get").mockReturnValue(1);
+      const expectedResult = timestamp.compact() / 1000 + 1;
+      const result = service.getNetworkTimestampFromUInt64(timestamp as any);
+      expect(configGetCall).toBeCalled();
+      expect(result).toEqual(expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
Fix the following @todo tasks:
- src//common/services/NetworkService.ts: * @todo Potentially add `nodePublicKey` to network configuration (for default node).
- src//common/services/NetworkService.ts: * @todo Move method {@link getBlockTimestamp} to helpers/formatters concern.
- src//common/services/NetworkService.ts: * @todo Move method {@link getNetworkTimestampFromUInt64} to helpers/formatters concern.
- src//common/services/NetworkService.ts: * @todo Deprecate method {@link getBlockRepository} in favor of {@link delegatePromises}.
- src//common/services/NetworkService.ts: * @todo Deprecate method {@link getTransactionRepository} in favor of {@link delegatePromises}.