### PR TITLE
Son/techn 338 enable multiple devices authentication

### DIFF
--- a/runtime/backend/src/common/models/AccountSchema.ts
+++ b/runtime/backend/src/common/models/AccountSchema.ts
@@ -138,51 +138,6 @@ export class Account extends Transferable<AccountDTO> {
   public readonly firstTransactionAtBlock?: number;
 
   /**
-   * The JWT access token that can be attached in the **bearer
-   * authorization header** of HTTP requests to indicate that
-   * a user is authenticated.
-   * <br /><br />
-   * This field is **optional** and *not indexed*.
-   * <br /><br />
-   * See more details in {@link AccessTokenDTO}.
-   *
-   * @access public
-   * @readonly
-   * @var {string}
-   */
-  @Prop({ required: false, nullable: true })
-  public readonly accessToken?: string;
-
-  /**
-   * The JWT refresh token that can be attached in the **bearer
-   * authorization header** of HTTP requests to `/auth/token` to
-   * indicate that a user's access token must be refreshed.
-   * <br /><br />
-   * This field is **optional** and *not indexed*.
-   * <br /><br />
-   * See more details in {@link AccessTokenDTO}.
-   *
-   * @access public
-   * @readonly
-   * @var {string}
-   */
-  @Prop({ index: true, nullable: true })
-  public readonly refreshTokenHash?: string;
-
-  /**
-   * The transaction hash that is/was attached to the **last**
-   * authenticated *session* of this account.
-   * <br /><br />
-   * This field is **optional** and *not indexed*.
-   *
-   * @access public
-   * @readonly
-   * @var {string}
-   */
-  @Prop({ nullable: true })
-  public readonly lastSessionHash?: string;
-
-  /**
    * The document's creation timestamp. This field **does not** reflect the
    * date of creation of an account but rather the date of creation of the
    * cached database entry.

--- a/runtime/backend/src/common/models/AccountSessionDTO.ts
+++ b/runtime/backend/src/common/models/AccountSessionDTO.ts
@@ -1,0 +1,148 @@
+/**
+ * This file is part of dHealth dApps Framework shared under LGPL-3.0
+ * Copyright (C) 2022-present dHealth Network, All rights reserved.
+ *
+ * @package     dHealth dApps Framework
+ * @subpackage  Backend
+ * @author      dHealth Network <devs@dhealth.foundation>
+ * @license     LGPL-3.0
+ */
+// external dependencies
+import { ApiProperty } from "@nestjs/swagger";
+
+// internal dependencies
+import { BaseDTO } from "./BaseDTO";
+
+/**
+ * @class AccountSessionDTO
+ * @description A DTO class that consists of the *transferable* properties
+ * of an account session.
+ *
+ * @since v0.3.2
+ */
+export class AccountSessionDTO extends BaseDTO {
+  /**
+   * The Address of this account on dHealth Network. The
+   * account's **address** typically refers to a human-readable
+   * series of 39 characters, starting either with a `T`, for
+   * TESTNET addresses, or with a `N`, for MAINNET addresses.
+   *
+   * @example `"NDAPPH6ZGD4D6LBWFLGFZUT2KQ5OLBLU32K3HNY"`
+   * @access public
+   * @var {string}
+   */
+  @ApiProperty({
+    type: "string",
+    example: "NDAPPH6ZGD4D6LBWFLGFZUT2KQ5OLBLU32K3HNY",
+    description: "The Address of this account on dHealth Network",
+  })
+  public address: string;
+
+  /**
+   * The account's referral code. This code should be used when inviting
+   * new users to the dApp. This field contains a unique random string of
+   * 8 characters.
+   *
+   * @access public
+   * @var {number}
+   */
+  @ApiProperty({
+    type: "string",
+    example: "JOINFIT22-4234432424",
+    description:
+      "The account's referral code. This code should be used when inviting new users to the dApp.",
+  })
+  public referralCode: string;
+
+  /**
+   * The account's **referrer address**. This address refers to the
+   * account that *invited* the current account to the dApp.
+   * <br /><br />
+   * This field is **optional** and *indexed*.
+   *
+   * @access public
+   * @readonly
+   * @var {string}
+   */
+  @ApiProperty({
+    type: "string",
+    example: "NDAPPH6ZGD4D6LBWFLGFZUT2KQ5OLBLU32K3HNY",
+    description:
+      "The account's referrer address. This address refers to the account whom *invited* the current account to the dApp.",
+  })
+  public referredBy?: string;
+
+  /**
+   * The JWT sub value that can be attached in the **bearer
+   * authorization header** of HTTP requests to serve as a
+   * unique identity of each device.
+   *
+   * @access public
+   * @var {string}
+   */
+  @ApiProperty({
+    type: "string",
+    example: "5d60ad3bcd08fa119b77a7e5ef72dae509d291e33ccf75d93b4c155e61db55d7",
+    description: "The JWT sub value that can be attached in the **bearer authorization header** of HTTP requests to serve as a unique identity of each device.",
+  })
+  public sub: string;
+
+  /**
+   * The JWT access token that can be attached in the **bearer
+   * authorization header** of HTTP requests to indicate users
+   * that are authenticated ("logged in").
+   * <br /><br />
+   * Access tokens are always **signed** with the dApp's auth
+   * secret and expire after 1 hour (one hour).
+   *
+   * @access public
+   * @var {string}
+   */
+  @ApiProperty({
+    type: "string",
+    example:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    description:
+      "The JWT access token that can be attached in the **bearer authorization header** of HTTP requests to indicate users that are authenticated - a.k.a logged in.",
+  })
+  public accessToken?: string;
+
+  /**
+   * The JWT refresh token that can be attached in the **bearer
+   * authorization header** of HTTP requests to `/auth/token` to
+   * indicate that a user's access token must be refreshed.
+   * <br /><br />
+   * Refresh tokens are always **signed** with the dApp's auth
+   * secret and expire after 1 year (one year).
+   *
+   * @access public
+   * @var {string}
+   */
+  @ApiProperty({
+    type: "string",
+    example:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    description:
+      "The JWT refresh token that can be attached in the **bearer authorization header** of HTTP requests to `/auth/token` to indicate that a user's access token must be refreshed.",
+  })
+  public refreshTokenHash?: string;
+
+  /**
+   * The transaction hash that is/was attached to the **last**
+   * authenticated *session* of this account.
+   * <br /><br />
+   * This field is **optional** and *not indexed*.
+   *
+   * @access public
+   * @readonly
+   * @var {string}
+   */
+  @ApiProperty({
+    type: "string",
+    example:
+      "3BB567908EFB0A6B642EE984D4DEC7CA4854266984DCB416164350B2A1078089",
+    description:
+      "The transaction hash that is/was attached to the last authenticated session of this account.",
+  })
+  public lastSessionHash?: string;
+}

--- a/runtime/backend/src/common/models/AccountSessionSchema.ts
+++ b/runtime/backend/src/common/models/AccountSessionSchema.ts
@@ -1,0 +1,300 @@
+/**
+ * This file is part of dHealth dApps Framework shared under LGPL-3.0
+ * Copyright (C) 2022-present dHealth Network, All rights reserved.
+ *
+ * @package     dHealth dApps Framework
+ * @subpackage  Backend
+ * @author      dHealth Network <devs@dhealth.foundation>
+ * @license     LGPL-3.0
+ */
+// external dependencies
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { Model } from "mongoose";
+
+// internal dependencies
+import { Documentable } from "../concerns/Documentable";
+import { Transferable } from "../concerns/Transferable";
+import { Queryable, QueryParameters } from "../concerns/Queryable";
+import { AccountSessionDTO } from "./AccountSessionDTO";
+
+/**
+ * @class AccountSession
+ * @description This class defines the **exact** fields that are
+ * stored in the corresponding MongoDB documents. It should be
+ * used whenever database *documents* are being handled or read
+ * for the `account-sessions` collection.
+ * <br /><br />
+ * Note that this class uses the generic {@link Transferable} trait to
+ * enable a `toDTO()` method on the model.
+ *
+ * @todo Timestamp fields should be **numbers** to avoid timezone issues.
+ * @since v0.3.2
+ */
+ @Schema({
+  timestamps: true,
+  collection: "account-sessions",
+})
+export class AccountSession extends Transferable<AccountSessionDTO> {
+  /**
+   * This field contains the *mongo collection name* for entries
+   * that are stored using {@link AccountSessionDocument} or the model
+   * {@link AccountSessionModel}.
+   * <br /><br />
+   * Note that this field **is not** part of document properties
+   * and used only internally to perform queries that refer to
+   * an individual collection name, e.g. `$unionWith`.
+   *
+   * @access public
+   * @var {string}
+   */
+  public collectionName = "account-sessions";
+
+  /**
+   * The account's **address**. An address typically refers to a
+   * human-readable series of 39 characters, starting either with
+   * a `T`, for TESTNET addresses, or with a `N`, for MAINNET addresses.
+   * <br /><br />
+   * This field is **required**, *indexed* and values are expected
+   * to be *unique*.
+   *
+   * @access public
+   * @readonly
+   * @var {string}
+   */
+  @Prop({ required: true, index: true, type: String })
+  public readonly address: string;
+
+  /**
+   * The JWT sub value that can be attached in the **bearer
+   * authorization header** of HTTP requests to serve as a
+   * unique identity of each device.
+   * <br /><br />
+   * This field is *not indexed*.
+   *
+   * @access public
+   * @readonly
+   * @var {string}
+   */
+  @Prop({ required: true, type: String })
+  public readonly sub: string;
+
+  /**
+   * The JWT access token that can be attached in the **bearer
+   * authorization header** of HTTP requests to indicate that
+   * a user is authenticated.
+   * <br /><br />
+   * This field is **optional** and *not indexed*.
+   * <br /><br />
+   * See more details in {@link AccessTokenDTO}.
+   *
+   * @access public
+   * @readonly
+   * @var {string}
+   */
+  @Prop({ required: false, nullable: true })
+  public readonly accessToken?: string;
+
+  /**
+  * The JWT refresh token that can be attached in the **bearer
+  * authorization header** of HTTP requests to `/auth/token` to
+  * indicate that a user's access token must be refreshed.
+  * <br /><br />
+  * This field is **optional** and *not indexed*.
+  * <br /><br />
+  * See more details in {@link AccessTokenDTO}.
+  *
+  * @access public
+  * @readonly
+  * @var {string}
+  */
+  @Prop({ index: true, nullable: true })
+  public readonly refreshTokenHash?: string;
+
+  /**
+  * The transaction hash that is/was attached to the **last**
+  * authenticated *session* of this account.
+  * <br /><br />
+  * This field is **optional** and *not indexed*.
+  *
+  * @access public
+  * @readonly
+  * @var {string}
+  */
+  @Prop({ nullable: true })
+  public readonly lastSessionHash?: string;
+
+  /**
+   * The account's **referrer address**. This address refers to the
+   * account that *invited* the current account to the dApp.
+   * <br /><br />
+   * This field is **optional** and *indexed*.
+   *
+   * @access public
+   * @readonly
+   * @var {string}
+   */
+  @Prop({ index: true })
+  public readonly referredBy?: string;
+
+  /**
+   * The account's referral code. This code should be used when inviting
+   * new users to the dApp. This field contains a unique random string of
+   * 8 characters.
+   * <br /><br />
+   * This field is **required**, *indexed* and values are expected
+   * to be *unique*.
+   *
+   * @access public
+   * @readonly
+   * @var {string}
+   */
+  @Prop({ required: true, index: true, unique: true, type: String })
+  public readonly referralCode: string;
+
+  /**
+  * The document's creation timestamp. This field **does not** reflect the
+  * date of creation of an account but rather the date of creation of the
+  * cached database entry.
+  * <br /><br />
+  * This field is **optional** and *indexed*.
+  *
+  * @access public
+  * @readonly
+  * @var {Date}
+  */
+  @Prop({ index: true })
+  public readonly createdAt?: Date;
+
+  /**
+  * The document's update timestamp. This field **does not** reflect the
+  * date of update of an account but rather the date of update of the
+  * cached database entry.
+  * <br /><br />
+  * This field is **optional** and *not indexed*.
+  *
+  * @access public
+  * @readonly
+  * @var {Date}
+  */
+  @Prop()
+  public readonly updatedAt?: Date;
+
+  /**
+   * This method implements a specialized query format to query items
+   * individually, as documents, in the collection: `account-sessions`.
+   *
+   * @access public
+   * @returns {Record<string, unknown>}    The individual document data that is used in a query.
+   */
+  public get toQuery(): Record<string, unknown> {
+    return {
+      address: this.address,
+    };
+  }
+
+  /**
+   * This *static* method populates a {@link AccountSessionDTO} object from the
+   * values of a {@link AccountSessionDocument} as presented by mongoose queries.
+   *
+   * @access public
+   * @static
+   * @param   {AccountSessionDocument}   doc   The document as received from mongoose.
+   * @param   {AccountSessionDTO}        dto   The DTO object that will be populated with values.
+   * @returns {AccountSessionDTO}        The `dto` object with fields set.
+   */
+  public static fillDTO(doc: AccountSessionDocument, dto: AccountSessionDTO): AccountSessionDTO {
+    dto.address = doc.address;
+    dto.accessToken = doc.accessToken;
+    dto.refreshTokenHash = doc.refreshTokenHash;
+    dto.lastSessionHash = doc.lastSessionHash;
+    dto.referralCode = doc.referralCode;
+    dto.referredBy = doc.referredBy;
+    return dto;
+  }
+}
+
+/**
+ * @type AccountSessionDocument
+ * @description This type is used to interface entities of the
+ * `account-sessions` collection with *mongoose* and permits to
+ * instanciate objects representing these entities.
+ * <br /><br />
+ * e.g. alongside {@link AccountSessionSchema}, we also define
+ * `AccountDocument` which is a mixin that comprises of
+ * {@link AccountSession} and this `Documentable` class.
+ * <br /><br />
+ * In class {@link Queryable:COMMON}, the first generic accepted
+ * permits to use *documents* that are typed with this, to filter
+ * results in a documents query.
+ *
+ * @since v0.3.2
+ */
+ export type AccountSessionDocument = AccountSession & Documentable;
+
+/**
+ * @class AccountSessionModel
+ * @description This class defines the **model** or individual
+ * **document** for one collection ("schema"). This class can
+ * be *automatically* injected in services using the `@InjectModel`
+ * decorator of `nestjs/mongoose`.
+ * <br /><br />
+ * @example Injecting and using the `AccountSessionModel`
+ * ```typescript
+ *   import { InjectModel } from "@nestjs/mongoose";
+ *   import { AccountSession, AccountSessionModel } from "./AccountSessionSchema";
+ *
+ *   class MyAccountService {
+ *     public constructor(
+ *       @InjectModel(AccountSession.name) private readonly model: AccountSessionModel
+ *     )
+ *
+ *     public addEntry(data: Record<string, any>) {
+ *       return this.model.create(data);
+ *     }
+ *   }
+ * ```
+ *
+ * @since v0.3.2
+ */
+export class AccountSessionModel extends Model<AccountSessionDocument> {}
+
+/**
+ * @class AccountSessionQuery
+ * @description This class augments {@link Queryable} objects enabling
+ * *account-sessions* to be queried **by `address`** and **by `transactionsCount`.**
+ * <br /><br />
+ * The main purpose of this class shall be to perform queries against
+ * the `account-sessions` collection.
+ *
+ * @since v0.3.2
+ */
+export class AccountSessionQuery extends Queryable<AccountSessionDocument> {
+  /**
+   * Copy constructor for pageable queries in `account-sessions` collection.
+   *
+   * @see Queryable
+   * @param   {AccountSessionDocument|undefined}     document          The *document* instance (defaults to `undefined`) (optional).
+   * @param   {QueryParameters|undefined}            queryParameters   The query parameters including as defined in {@link QueryParameters} (optional).
+   */
+  public constructor(
+    document?: AccountSessionDocument,
+    queryParams: QueryParameters = undefined,
+  ) {
+    super(document, queryParams);
+  }
+}
+
+/**
+ * @export AccountSessionSchema
+ * @description This export creates a mongoose schema using the custom
+ * {@link AccountSession} class and should be used mainly when *inferring* the
+ * type of fields in a document for the corresponding collection.
+ *
+ * @since v0.3.2
+ */
+export const AccountSessionSchema = SchemaFactory.createForClass(AccountSession);
+
+// This call to **loadClass** on the schema object enables instance
+// methods on the {@link AccountSession} class to be called when the model gets
+// instanciated by `mongoose` directly, e.g. as the result of a query.
+AccountSessionSchema.loadClass(AccountSession, true);

--- a/runtime/backend/src/common/models/index.ts
+++ b/runtime/backend/src/common/models/index.ts
@@ -25,6 +25,7 @@ export * from "./AuthChallengeSchema";
 export * from "./LogSchema";
 export * from "./StateSchema";
 export * from "./TransactionSchema";
+export * from "./AccountSessionSchema";
 
 // generic types / utilities
 export * from "./BaseDTO";
@@ -47,3 +48,4 @@ export * from "./SocialPlatformDTO";
 export * from "./StateDTO";
 export * from "./StatusDTO";
 export * from "./LogDTO";
+export * from "./AccountSessionDTO";

--- a/runtime/backend/src/common/modules/AccountSessionsModule.ts
+++ b/runtime/backend/src/common/modules/AccountSessionsModule.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of dHealth dApps Framework shared under LGPL-3.0
+ * Copyright (C) 2022-present dHealth Network, All rights reserved.
+ *
+ * @package     dHealth dApps Framework
+ * @subpackage  Backend
+ * @author      dHealth Network <devs@dhealth.foundation>
+ * @license     LGPL-3.0
+ */
+// external dependencies
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+
+// internal dependencies
+import { QueryModule } from "../../common/modules/QueryModule";
+import { AccountSession, AccountSessionSchema } from "../models/AccountSessionSchema";
+import { AccountSessionsService } from "../services/AccountSessionsService";
+
+
+/**
+ * @label COMMON
+ * @class AccountSessionsModule
+ * @description The main definition for the AccountSessions module.
+ *
+ * @since v0.3.2
+ */
+@Module({
+  providers: [AccountSessionsService],
+  imports: [
+    MongooseModule.forFeature([
+      { name: AccountSession.name, schema: AccountSessionSchema },
+    ]),
+    QueryModule,
+  ],
+  exports: [AccountSessionsService],
+})
+export class AccountSessionsModule {}

--- a/runtime/backend/src/common/modules/AuthModule.ts
+++ b/runtime/backend/src/common/modules/AuthModule.ts
@@ -14,7 +14,7 @@ import { JwtModule } from "@nestjs/jwt";
 import { MongooseModule } from "@nestjs/mongoose";
 
 // internal dependencies
-import { AccountsModule } from "../modules/AccountsModule";
+import { AccountSessionsModule } from "./AccountSessionsModule";
 import { ChallengesModule } from "../modules/ChallengesModule";
 import { NetworkModule } from "../modules/NetworkModule";
 import { QueryModule } from "../modules/QueryModule";
@@ -33,9 +33,11 @@ import {
 import { Account, AccountSchema } from "../models/AccountSchema";
 import { CipherService } from "../services/CipherService";
 import { SocialController } from "../routes/SocialController";
+import { AccountsModule } from "./AccountsModule";
 
 // configuration resources
 import securityConfigLoader from "../../../config/security";
+import { RefreshStrategy } from "../traits";
 const auth = securityConfigLoader().auth;
 
 /**
@@ -50,6 +52,7 @@ const auth = securityConfigLoader().auth;
     NetworkModule,
     QueryModule,
     AccountsModule,
+    AccountSessionsModule,
     ChallengesModule,
     PassportModule,
     LogModule,
@@ -66,7 +69,7 @@ const auth = securityConfigLoader().auth;
     ]),
   ],
   controllers: [AuthController, SocialController],
-  providers: [AuthService, AuthStrategy, CipherService],
+  providers: [AuthService, AuthStrategy, RefreshStrategy, CipherService],
   exports: [AuthService, CipherService],
 })
 export class AuthModule {}

--- a/runtime/backend/src/common/requests/AccessTokenRequest.ts
+++ b/runtime/backend/src/common/requests/AccessTokenRequest.ts
@@ -57,4 +57,19 @@ export class AccessTokenRequest {
       "A referral code *may* be attached to this request to mark that the authenticating account was *invited* to the dApp by another account.",
   })
   public referralCode?: string;
+
+  /**
+   * The JWT sub value that can be attached in the **bearer
+   * authorization header** of HTTP requests to serve as a
+   * unique identity of each device.
+   *
+   * @access public
+   * @var {string}
+   */
+  @ApiProperty({
+    example: "5d60ad3bcd08fa119b77a7e5ef72dae509d291e33ccf75d93b4c155e61db55d7",
+    description:
+      "The JWT sub value that can be attached in the **bearer authorization header** of HTTP requests to serve as a unique identity of each device.",
+  })
+  public sub: string;
 }

--- a/runtime/backend/src/common/services/AccountSessionsService.ts
+++ b/runtime/backend/src/common/services/AccountSessionsService.ts
@@ -1,0 +1,146 @@
+/**
+ * This file is part of dHealth dApps Framework shared under LGPL-3.0
+ * Copyright (C) 2022-present dHealth Network, All rights reserved.
+ *
+ * @package     dHealth dApps Framework
+ * @subpackage  Backend
+ * @author      dHealth Network <devs@dhealth.foundation>
+ * @license     LGPL-3.0
+ */
+// external dependencies
+import { Injectable } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+
+// internal dependencies
+import { PaginatedResultDTO } from "../models/PaginatedResultDTO";
+import { QueryService } from "../services/QueryService";
+import {
+  AccountSession,
+  AccountSessionDocument,
+  AccountSessionModel,
+  AccountSessionQuery,
+} from "../models/AccountSessionSchema";
+
+/**
+ * @class AccountsService
+ * @description The main service to handle documents in the
+ * `accounts` collection.
+ *
+ * @since v0.1.0
+ */
+@Injectable()
+export class AccountSessionsService {
+  /**
+   * The constructor of the service.
+   *
+   * @constructor
+   * @param {AccountSessionModel} model
+   * @param {QueriesService} queriesService
+   */
+  constructor(
+    @InjectModel(AccountSession.name) private readonly model: AccountSessionModel,
+    private readonly queriesService: QueryService<
+      AccountSessionDocument,
+      AccountSessionModel
+    >,
+  ) {}
+
+  /**
+   * This method executes a *count* query using the {@link model}
+   * argument.
+   * <br /><br />
+   * Caution: Count queries require a considerable amount of RAM
+   * to execute. It is preferred to use pro-active statistics with
+   * collections that contain one document with a counter.
+   *
+   * @param   {AccountSessionQuery}  query
+   * @returns {Promise<number>}   The number of matching accounts.
+   */
+  async count(query: AccountSessionQuery): Promise<number> {
+    return await this.queriesService.count(query, this.model);
+  }
+
+  /**
+   * Method to query the *existence* of a document in the
+   * `account-sessions` collection.
+   * <br /><br />
+   * This executes a *lean* mongoose query such that the
+   * properties of the returned document are *reduced* to
+   * only the `"_id"` field.
+   *
+   * @param   {AccountSessionQuery}  query   The query configuration with `sort`, `order`, `pageNumber`, `pageSize`.
+   * @returns {Promise<boolean>}  Whether a document exists which validates the passed query.
+   */
+  public async exists(query: AccountSessionQuery): Promise<boolean> {
+    // executes a *lean* mongoose findOne query
+    const document: AccountSessionDocument = await this.queriesService.findOne(
+      query,
+      this.model,
+      true, // stripDocument ("lean query")
+    );
+
+    // https://simplernerd.com/typescript-convert-bool/
+    return !!document;
+  }
+
+  /**
+   * Method to query account sessions based on query and returns as paginated result.
+   *
+   * @async
+   * @param   {AccountSessionQuery} query
+   * @returns {Promise<PaginatedResultDTO<AccountDocument>>}
+   */
+  public async find(
+    query: AccountSessionQuery,
+  ): Promise<PaginatedResultDTO<AccountSessionDocument>> {
+    return await this.queriesService.find(query, this.model);
+  }
+
+  /**
+   * Find one `AccountSessionDocument` instance in the database and use
+   * a query based on the {@link Queryable} class.
+   * <br /><br />
+   *
+   * @access public
+   * @async
+   * @param   {AccountSessionQuery}            query     The query configuration with `sort`, `order`, `pageNumber`, `pageSize`.
+   * @returns {Promise<AccountSessionDocument>}  The resulting `accounts` document.
+   */
+  public async findOne(query: AccountSessionQuery): Promise<AccountSessionDocument> {
+    return await this.queriesService.findOne(query, this.model);
+  }
+
+  /**
+   * This method updates *exactly one document* in a collection.
+   * <br /><br />
+   *
+   * @async
+   * @param   {AccountSessionQuery}           query   The query configuration with `sort`, `order`, `pageNumber`, `pageSize`.
+   * @param   {AccountSessionModel}           data    The fields or data that has to be updated (will be added to `$set: {}`).
+   * @param   {Record<string, any>}           ops    The operations that must be run additionally (e.g. `$inc: {}`) (optional).
+   * @returns {Promise<AccountSessionDocument>}  The *updated* `accounts` document.
+   */
+  public async createOrUpdate(
+    query: AccountSessionQuery,
+    data: AccountSessionModel,
+    ops: Record<string, any> = {},
+  ): Promise<AccountSessionDocument> {
+    return await this.queriesService.createOrUpdate(
+      query,
+      this.model,
+      data,
+      ops,
+    );
+  }
+
+  /**
+   * Method to update a batch of account sessions.
+   *
+   * @async
+   * @param   {AccountSessionModel[]} accountDocuments
+   * @returns {Promise<number>}
+   */
+  public async updateBatch(accountSessionDocuments: AccountSessionModel[]): Promise<number> {
+    return await this.queriesService.updateBatch(this.model, accountSessionDocuments);
+  }
+}

--- a/runtime/backend/src/common/traits/AuthStrategy.ts
+++ b/runtime/backend/src/common/traits/AuthStrategy.ts
@@ -21,6 +21,8 @@ import { AuthenticationPayload } from "../services/AuthService";
 // configuration resources
 import dappConfigLoader from "../../../config/dapp";
 import securityConfigLoader from "../../../config/security";
+import { AccountSessionDocument, AccountSessionQuery } from "../models/AccountSessionSchema";
+import { AccountSessionsService } from "../services/AccountSessionsService";
 const conf = dappConfigLoader();
 const auth = securityConfigLoader().auth;
 
@@ -38,7 +40,7 @@ export class AuthStrategy extends PassportStrategy(Strategy) {
   /**
    *
    */
-  public constructor(private readonly accountsService: AccountsService) {
+  public constructor(private readonly accountSessionsService: AccountSessionsService) {
     super({
       // determines the *token* extraction method
       jwtFromRequest: ExtractJwt.fromExtractors([
@@ -77,16 +79,17 @@ export class AuthStrategy extends PassportStrategy(Strategy) {
   ): Promise<AuthenticationPayload> {
     // finds an `accounts` document that corresponds
     // the authentication payload's dHealth address.
-    const account: AccountDocument = await this.accountsService.findOne(
-      new AccountQuery({
+    const accountSession: AccountSessionDocument = await this.accountSessionsService.findOne(
+      new AccountSessionQuery({
         address: payload.address,
-      } as AccountDocument),
+        sub: payload.sub,
+      } as AccountSessionDocument),
     );
 
     // re-build the authentication payload
     return {
-      sub: account.lastSessionHash,
-      address: account.address,
+      sub: accountSession.lastSessionHash,
+      address: accountSession.address,
     } as AuthenticationPayload;
   }
 }

--- a/runtime/backend/src/common/traits/RefreshStrategy.ts
+++ b/runtime/backend/src/common/traits/RefreshStrategy.ts
@@ -15,9 +15,9 @@ import { Request } from "express";
 import { sha3_256 } from "js-sha3";
 
 // internal dependencies
-import { AccountDocument, AccountQuery } from "../models/AccountSchema";
-import { AccountsService } from "../services/AccountsService";
 import { AuthenticationPayload, AuthService } from "../services/AuthService";
+import { AccountSessionsService } from "../services/AccountSessionsService";
+import { AccountSessionDocument, AccountSessionQuery } from "../models/AccountSessionSchema";
 
 // configuration resources
 import dappConfigLoader from "../../../config/dapp";
@@ -39,7 +39,7 @@ export class RefreshStrategy extends PassportStrategy(Strategy, "jwt-refresh") {
   /**
    *
    */
-  public constructor(private readonly accountsService: AccountsService) {
+  public constructor(private readonly accountSessionsService: AccountSessionsService) {
     super({
       // determines the *token* extraction method
       jwtFromRequest: ExtractJwt.fromExtractors([
@@ -86,11 +86,11 @@ export class RefreshStrategy extends PassportStrategy(Strategy, "jwt-refresh") {
 
     // finds an `accounts` document using a SHA3-256
     // hash of the refresh token (never plain text).
-    const account: AccountDocument = await this.accountsService.findOne(
-      new AccountQuery({
+    const account: AccountSessionDocument = await this.accountSessionsService.findOne(
+      new AccountSessionQuery({
         address: payload.address,
         refreshTokenHash: sha3_256(refreshToken),
-      } as AccountDocument),
+      } as AccountSessionDocument),
     );
 
     // re-build the authentication payload

--- a/runtime/backend/tests/unit/AppController.spec.ts
+++ b/runtime/backend/tests/unit/AppController.spec.ts
@@ -18,6 +18,7 @@ import { MailerService } from "@nestjs-modules/mailer";
 import { MockModel } from "../mocks/global";
 import { AppController } from "../../src/AppController";
 import { AccountsService } from "../../src/common/services/AccountsService";
+import { AccountSessionsService } from "../../src/common/services/AccountSessionsService";
 import { ChallengesService } from "../../src/common/services/ChallengesService";
 import { NetworkService } from "../../src/common/services/NetworkService";
 import { AuthService } from "../../src/common/services/AuthService";
@@ -56,6 +57,7 @@ describe("AppController", () => {
         ConfigService, // requirement from AuthService
         NetworkService, // requirement from AuthService
         AccountsService, // requirement from AuthService
+        AccountSessionsService, // requirement from AuthService
         JwtService, // requirement from AuthService
         QueryService, // requirement from AccountsService
         ChallengesService, // requirement from AccountsService
@@ -65,6 +67,10 @@ describe("AppController", () => {
           provide: getModelToken("Account"),
           useValue: MockModel, // test/mocks/global.ts
         }, // requirement from AccountsService
+        {
+          provide: getModelToken("AccountSession"),
+          useValue: MockModel, // test/mocks/global.ts
+        }, // requirement from AccountsSessionService
         {
           provide: getModelToken("AccountIntegration"),
           useValue: MockModel, // test/mocks/global.ts

--- a/runtime/backend/tests/unit/AppModule.spec.ts
+++ b/runtime/backend/tests/unit/AppModule.spec.ts
@@ -25,6 +25,7 @@ import { AuthService } from "../../src/common/services/AuthService";
 import { OAuthService } from "../../src/oauth/services/OAuthService";
 import { NetworkService } from "../../src/common/services/NetworkService";
 import { AccountsService } from "../../src/common/services/AccountsService";
+import { AccountSessionsService } from "../../src/common/services/AccountSessionsService";
 import { ChallengesService } from "../../src/common/services/ChallengesService";
 import { QueryService } from "../../src/common/services/QueryService";
 import { CipherService } from "../../src/common/services/CipherService";
@@ -44,6 +45,7 @@ describe("AppModule", () => {
         CipherService, // requirement from OAuthService
         NetworkService, // requirement from AuthService
         AccountsService, // requirement from AuthService
+        AccountSessionsService, // requirement from AuthService
         ChallengesService, // requirement from AuthService
         JwtService, // requirement from AuthService
         QueryService, // requirement from AccountsService
@@ -56,6 +58,10 @@ describe("AppModule", () => {
           provide: getModelToken("Account"),
           useValue: MockModel,
         }, // requirement from AccountsService
+        {
+          provide: getModelToken("AccountSession"),
+          useValue: MockModel,
+        }, // requirement from AccountSessionsService
         {
           provide: getModelToken("AuthChallenge"),
           useValue: MockModel,

--- a/runtime/backend/tests/unit/common/routes/AuthController.spec.ts
+++ b/runtime/backend/tests/unit/common/routes/AuthController.spec.ts
@@ -22,17 +22,18 @@ import { JwtService } from "@nestjs/jwt";
 import { AuthService } from "../../../../src/common/services/AuthService";
 import { AuthController } from "../../../../src/common/routes/AuthController";
 import { AccountsService } from "../../../../src/common/services/AccountsService";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 import { CipherService } from "../../../../src/common/services/CipherService";
 import { NetworkService } from "../../../../src/common/services/NetworkService";
 import { ChallengesService } from "../../../../src/common/services/ChallengesService";
 import { QueryService } from "../../../../src/common/services/QueryService";
-import { AccountDocument } from "../../../../src/common/models/AccountSchema";
+import { AccountSessionDocument } from "../../../../src/common/models/AccountSessionSchema";
 import { MockModel } from "../../../mocks/global";
 
 describe("common/AuthController", () => {
   let controller: AuthController;
   let authService: AuthService;
-  let accountsService: AccountsService;
+  let accountSessionsService: AccountSessionsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -40,16 +41,21 @@ describe("common/AuthController", () => {
       providers: [
         AuthService, // requirement from AuthService
         AccountsService, // requirement from AuthController
+        AccountSessionsService, // requirement from AuthController
         ConfigService, // requirement from AuthService
         NetworkService, // requirement from AuthService
         ChallengesService, // requirement from AuthService
         JwtService, // requirement from AuthService
         CipherService, // requirement from OAuthService
-        QueryService, // requirement from AccountsService
+        QueryService, // requirement from AccountSessionsService
         {
           provide: getModelToken("Account"),
           useValue: MockModel,
-        }, // requirement from AccountsService
+        }, // requirement from AccountSessionsService
+        {
+          provide: getModelToken("AccountSession"),
+          useValue: MockModel,
+        }, // requirement from AccountSessionsService
         {
           provide: getModelToken("AuthChallenge"),
           useValue: MockModel,
@@ -59,7 +65,7 @@ describe("common/AuthController", () => {
 
     controller = module.get<AuthController>(AuthController);
     authService = module.get<AuthService>(AuthService);
-    accountsService = module.get<AccountsService>(AccountsService);
+    accountSessionsService = module.get<AccountSessionsService>(AccountSessionsService);
   });
 
   it("should be defined", () => {
@@ -179,8 +185,8 @@ describe("common/AuthController", () => {
         .spyOn(AuthService, "extractToken")
         .mockReturnValue("testToken");
       const accountsServiceFindOneCall = jest
-        .spyOn(accountsService, "findOne")
-        .mockResolvedValue({} as AccountDocument);
+        .spyOn(accountSessionsService, "findOne")
+        .mockResolvedValue({} as AccountSessionDocument);
       const tokens = {
         accessToken: "testAccessToken",
         refreshToken: "testRefreshToken",

--- a/runtime/backend/tests/unit/common/traits/AuthStrategy.spec.ts
+++ b/runtime/backend/tests/unit/common/traits/AuthStrategy.spec.ts
@@ -40,31 +40,31 @@ import { getModelToken } from "@nestjs/mongoose";
 
 // internal dependencies
 import { AuthStrategy } from "../../../../src/common/traits/AuthStrategy";
-import { AccountsService } from "../../../../src/common/services/AccountsService";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 import { QueryService } from "../../../../src/common/services/QueryService";
-import { AccountDocument } from "../../../../src/common/models/AccountSchema";
 import { MockModel } from "../../../mocks/global";
+import { AccountSessionDocument } from "../../../../src/common/models/AccountSessionSchema";
 
 describe("common/AuthStrategy", () => {
   let service: AuthStrategy;
-  let accountsService: AccountsService;
+  let accountSessionsService: AccountSessionsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MockPassportStrategy,
         AuthStrategy,
-        AccountsService,
+        AccountSessionsService,
         QueryService,
         {
-          provide: getModelToken("Account"),
+          provide: getModelToken("AccountSession"),
           useValue: MockModel,
         },
       ],
     }).compile();
 
     service = module.get<AuthStrategy>(AuthStrategy);
-    accountsService = module.get<AccountsService>(AccountsService);
+    accountSessionsService = module.get<AccountSessionsService>(AccountSessionsService);
   });
 
   it("should be defined", () => {
@@ -121,16 +121,16 @@ describe("common/AuthStrategy", () => {
   describe("validate()", () => {
     it("should return correct result", async () => {
       // prepare
-      const accountDoc = {
+      const accountSessionDoc = {
         address: "testAddress",
         lastSessionHash: "testLastSessionHash",
       }
       const accountsServiceFindOneCall = jest
-        .spyOn(accountsService, "findOne")
-        .mockResolvedValue(accountDoc as AccountDocument);
+        .spyOn(accountSessionsService, "findOne")
+        .mockResolvedValue(accountSessionDoc as AccountSessionDocument);
       const expectedResult = {
-        sub: accountDoc.lastSessionHash,
-        address: accountDoc.address,
+        sub: accountSessionDoc.lastSessionHash,
+        address: accountSessionDoc.address,
       }
       
       // act

--- a/runtime/backend/tests/unit/common/traits/RefreshStrategy.spec.ts
+++ b/runtime/backend/tests/unit/common/traits/RefreshStrategy.spec.ts
@@ -45,31 +45,31 @@ import { getModelToken } from "@nestjs/mongoose";
 
 // internal dependencies
 import { RefreshStrategy } from "../../../../src/common/traits/RefreshStrategy";
-import { AccountsService } from "../../../../src/common/services/AccountsService";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 import { QueryService } from "../../../../src/common/services/QueryService";
-import { AccountDocument } from "../../../../src/common/models/AccountSchema";
 import { MockModel } from "../../../mocks/global";
+import { AccountSessionDocument } from "../../../../src/common/models/AccountSessionSchema";
 
 describe("common/RefreshStrategy", () => {
   let service: RefreshStrategy;
-  let accountsService: AccountsService;
+  let accountSessionsService: AccountSessionsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MockPassportStrategy,
         RefreshStrategy,
-        AccountsService,
+        AccountSessionsService,
         QueryService,
         {
-          provide: getModelToken("Account"),
+          provide: getModelToken("AccountSession"),
           useValue: MockModel,
         },
       ],
     }).compile();
 
     service = module.get<RefreshStrategy>(RefreshStrategy);
-    accountsService = module.get<AccountsService>(AccountsService);
+    accountSessionsService = module.get<AccountSessionsService>(AccountSessionsService);
   });
 
   it("should be defined", () => {
@@ -126,16 +126,16 @@ describe("common/RefreshStrategy", () => {
   describe("validate()", () => {
     it("should return correct result", async () => {
       // prepare
-      const accountDoc = {
+      const accountSessionDoc = {
         address: "testAddress",
         lastSessionHash: "testLastSessionHash",
       }
       const accountsServiceFindOneCall = jest
-        .spyOn(accountsService, "findOne")
-        .mockResolvedValue(accountDoc as AccountDocument);
+        .spyOn(accountSessionsService, "findOne")
+        .mockResolvedValue(accountSessionDoc as AccountSessionDocument);
       const expectedResult = {
-        sub: accountDoc.lastSessionHash,
-        address: accountDoc.address,
+        sub: accountSessionDoc.lastSessionHash,
+        address: accountSessionDoc.address,
       }
       
       // act

--- a/runtime/backend/tests/unit/discovery/routes/AssetsController.spec.ts
+++ b/runtime/backend/tests/unit/discovery/routes/AssetsController.spec.ts
@@ -21,6 +21,7 @@ import { AuthService } from "../../../../src/common/services/AuthService";
 import { QueryService } from "../../../../src/common/services/QueryService";
 import { NetworkService } from "../../../../src/common/services/NetworkService";
 import { AccountsService } from "../../../../src/common/services/AccountsService";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 import { ChallengesService } from "../../../../src/common/services/ChallengesService";
 import { AssetDocument } from "../../../../src/discovery/models/AssetSchema";
 import { AccountDocument } from "../../../../src/common/models/AccountSchema";
@@ -40,6 +41,7 @@ describe("discovery/AssetsController", () => {
         QueryService,
         NetworkService,
         AccountsService,
+        AccountSessionsService,
         ChallengesService,
         JwtService,
         {
@@ -48,6 +50,10 @@ describe("discovery/AssetsController", () => {
         },
         {
           provide: getModelToken("Account"),
+          useValue: MockModel,
+        },
+        {
+          provide: getModelToken("AccountSession"),
           useValue: MockModel,
         },
         {

--- a/runtime/backend/tests/unit/oauth/routes/OAuthController.spec.ts
+++ b/runtime/backend/tests/unit/oauth/routes/OAuthController.spec.ts
@@ -24,6 +24,7 @@ import { OAuthController } from "../../../../src/oauth/routes/OAuthController";
 import { OAuthService } from "../../../../src/oauth/services/OAuthService";
 import { AuthService } from "../../../../src/common/services/AuthService";
 import { AccountsService } from "../../../../src/common/services/AccountsService";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 import { NetworkService } from "../../../../src/common/services/NetworkService";
 import { ChallengesService } from "../../../../src/common/services/ChallengesService";
 import { QueryService } from "../../../../src/common/services/QueryService";
@@ -46,6 +47,7 @@ describe("common/OAuthController", () => {
         QueryService, // requirement from OAuthService
         CipherService, // requirement from OAuthService
         AccountsService, // requirement from AuthService
+        AccountSessionsService, // requirement from AuthService
         ConfigService, // requirement from AuthService
         NetworkService, // requirement from AuthService
         ChallengesService, // requirement from AuthService
@@ -53,7 +55,11 @@ describe("common/OAuthController", () => {
         {
           provide: getModelToken("Account"),
           useValue: MockModel,
-        }, // requirement from AccountsService
+        }, // requirement from AccountSessionsService
+        {
+          provide: getModelToken("AccountSession"),
+          useValue: MockModel,
+        }, // requirement from AccountSessionsService
         {
           provide: getModelToken("AuthChallenge"),
           useValue: MockModel,

--- a/runtime/backend/tests/unit/oauth/services/OAuthService.spec.ts
+++ b/runtime/backend/tests/unit/oauth/services/OAuthService.spec.ts
@@ -25,12 +25,13 @@ import { JwtService } from "@nestjs/jwt";
 import { MockModel } from "../../../mocks/global";
 import { NetworkService } from "../../../../src/common/services/NetworkService";
 import { AccountsService } from "../../../../src/common/services/AccountsService";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 import { CipherService } from "../../../../src/common/services/CipherService";
 import { QueryService } from "../../../../src/common/services/QueryService";
 import { AuthService } from "../../../../src/common/services/AuthService";
 import { ChallengesService } from "../../../../src/common/services/ChallengesService";
 import { OAuthService } from "../../../../src/oauth/services/OAuthService";
-import { AccountDocument } from "../../../../src/common/models/AccountSchema";
+import { AccountSessionDocument } from "../../../../src/common/models/AccountSessionSchema";
 import { PaginatedResultDTO } from "../../../../src/common/models/PaginatedResultDTO";
 import { OAuthCallbackRequest } from "../../../../src/oauth/requests/OAuthCallbackRequest";
 import {
@@ -53,6 +54,7 @@ describe("common/OAuthService", () => {
         OAuthService,
         NetworkService, // requirement from AuthService
         AccountsService, // requirement from AuthService
+        AccountSessionsService, // requirement from AuthService
         ChallengesService, // requirement from AuthService
         JwtService, // requirement from AuthService
         AuthService, // requirement from OAuthService
@@ -65,6 +67,10 @@ describe("common/OAuthService", () => {
         }, // requirement from OAuthService
         {
           provide: getModelToken("Account"),
+          useValue: MockModel,
+        }, // requirement from AuthService
+        {
+          provide: getModelToken("AccountSession"),
           useValue: MockModel,
         }, // requirement from AuthService
         {
@@ -363,7 +369,7 @@ describe("common/OAuthService", () => {
     it("should use correct database query parameters", async () => {
       // act
       await oauthService.getIntegrations(
-        { address: "fake-address" } as AccountDocument,
+        { address: "fake-address" } as AccountSessionDocument,
       );
 
       // assert
@@ -376,7 +382,7 @@ describe("common/OAuthService", () => {
     it("should accept any address in string format", async () => {
       // act
       await oauthService.getIntegrations(
-        { address: "another-fake-address" } as AccountDocument,
+        { address: "another-fake-address" } as AccountSessionDocument,
       );
 
       // assert
@@ -399,7 +405,7 @@ describe("common/OAuthService", () => {
 
       // act
       const result = await oauthService.getIntegrations(
-        { address: "fake-address" } as AccountDocument,
+        { address: "fake-address" } as AccountSessionDocument,
       );
 
       // assert
@@ -574,7 +580,7 @@ describe("common/OAuthService", () => {
       try {
         await oauthService.oauthCallback(
           "strava",
-          { address: "fake-address" } as AccountDocument,
+          { address: "fake-address" } as AccountSessionDocument,
           validCallbackRequest,
         );
       } catch(e: any) {
@@ -591,7 +597,7 @@ describe("common/OAuthService", () => {
       // act
       await oauthService.oauthCallback(
         "fake-provider",
-        { address: "fake-address" } as AccountDocument,
+        { address: "fake-address" } as AccountSessionDocument,
         validCallbackRequest,
       );
 
@@ -606,7 +612,7 @@ describe("common/OAuthService", () => {
       // act
       await oauthService.oauthCallback(
         "fake-provider",
-        { address: "fake-address" } as AccountDocument,
+        { address: "fake-address" } as AccountSessionDocument,
         validCallbackRequest,
       );
 
@@ -629,7 +635,7 @@ describe("common/OAuthService", () => {
       // act
       await oauthService.oauthCallback(
         "fake-provider",
-        { address: "fake-address" } as AccountDocument,
+        { address: "fake-address" } as AccountSessionDocument,
         validCallbackRequest,
       );
 

--- a/runtime/backend/tests/unit/payout/routes/PayoutsController.spec.ts
+++ b/runtime/backend/tests/unit/payout/routes/PayoutsController.spec.ts
@@ -25,6 +25,7 @@ import { AccountDocument } from "../../../../src/common/models/AccountSchema";
 import { PayoutDocument } from "../../../../src/payout/models/PayoutSchema";
 import { PayoutsService } from "../../../../src/payout/services/PayoutsService";
 import { PayoutsController } from "../../../../src/payout/routes/PayoutsController";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 
 describe("payout/PayoutsController", () => {
   let controller: PayoutsController;
@@ -43,6 +44,7 @@ describe("payout/PayoutsController", () => {
         AccountsService,
         ChallengesService,
         JwtService,
+        AccountSessionsService,
         {
           provide: getModelToken("Payout"),
           useValue: MockModel,
@@ -53,6 +55,10 @@ describe("payout/PayoutsController", () => {
         },
         {
           provide: getModelToken("AuthChallenge"),
+          useValue: MockModel,
+        },
+        {
+          provide: getModelToken("AccountSession"),
           useValue: MockModel,
         },
       ],

--- a/runtime/backend/tests/unit/payout/schedulers/PrepareActivityPayouts.spec.ts
+++ b/runtime/backend/tests/unit/payout/schedulers/PrepareActivityPayouts.spec.ts
@@ -32,6 +32,7 @@ import { PayoutsService } from "../../../../src/payout/services/PayoutsService";
 import { SignerService } from "../../../../src/payout/services/SignerService";
 import { MathService } from "../../../../src/payout/services/MathService";
 import { PrepareActivityPayouts } from "../../../../src/payout/schedulers/ActivityPayouts/PrepareActivityPayouts";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 
 const dE_2 = 100; // elevate factor with div=2
 const dE_3 = 1000; // elevate factor with div=3
@@ -160,6 +161,7 @@ describe("payout/PrepareActivityPayouts", () => {
         SignerService,
         MathService,
         EventEmitter2,
+        AccountSessionsService,
         {
           provide: getModelToken("Payout"),
           useValue: MockModel,
@@ -181,6 +183,10 @@ describe("payout/PrepareActivityPayouts", () => {
             debug: jest.fn(),
             error: jest.fn(),
           },
+        },
+        {
+          provide: getModelToken("AccountSession"),
+          useValue: MockModel,
         },
       ]
     }).compile();

--- a/runtime/backend/tests/unit/statistics/routes/LeaderboardsController.spec.ts
+++ b/runtime/backend/tests/unit/statistics/routes/LeaderboardsController.spec.ts
@@ -31,6 +31,7 @@ import {
 } from '../../../../src/statistics/models/StatisticsSchema';
 import { LeaderboardsController } from '../../../../src/statistics/routes/LeaderboardsController';
 import { StatisticsService } from '../../../../src/statistics/services/StatisticsService';
+import { AccountSessionsService } from '../../../../src/common/services/AccountSessionsService';
 
 describe('statistics/LeaderboardsController', () => {
   let controller: LeaderboardsController;
@@ -41,18 +42,23 @@ describe('statistics/LeaderboardsController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LeaderboardsController],
       providers: [
-        AuthService, // requirement from StatisticsService
-        NetworkService, // requirement from AuthService
-        AccountsService, // requirement from AuthService
-        ChallengesService, // requirement from AuthService
-        JwtService, // requirement from AuthService
-        QueryService, // requirement from AuthService
-        ConfigService, // requirement from AuthService
-        StatisticsService, // requirement from UsersController
+        AuthService,
+        QueryService,
+        AccountsService,
+        AccountSessionsService,
+        ConfigService,
+        NetworkService,
+        ChallengesService,
+        StatisticsService,
+        JwtService,
         {
           provide: getModelToken("Account"),
           useValue: MockModel,
         }, // requirement from AuthService
+        {
+          provide: getModelToken("AccountSession"),
+          useValue: MockModel,
+        },
         {
           provide: getModelToken("AuthChallenge"),
           useValue: MockModel,

--- a/runtime/backend/tests/unit/statistics/routes/UsersController.spec.ts
+++ b/runtime/backend/tests/unit/statistics/routes/UsersController.spec.ts
@@ -25,6 +25,7 @@ import { AccountDocument } from "../../../../src/common/models/AccountSchema";
 import { StatisticsService } from "../../../../src/statistics/services/StatisticsService";
 import { UsersController } from "../../../../src/statistics/routes/UsersController";
 import { StatisticsDocument } from "../../../../src/statistics/models/StatisticsSchema";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 
 describe("statistics/UsersController", () => {
   let controller: UsersController;
@@ -43,6 +44,7 @@ describe("statistics/UsersController", () => {
         QueryService, // requirement from AuthService
         ConfigService, // requirement from AuthService
         StatisticsService, // requirement from UsersController
+        AccountSessionsService, // requirement rom AuthService
         {
           provide: getModelToken("Account"),
           useValue: MockModel,
@@ -55,6 +57,10 @@ describe("statistics/UsersController", () => {
           provide: getModelToken("Statistics"),
           useValue: MockModel,
         }, // requirement from StatisticsService
+        {
+          provide: getModelToken("AccountSession"),
+          useValue: MockModel,
+        }, // requirement from AuthService
       ]
     }).compile();
 

--- a/runtime/backend/tests/unit/users/routes/ActivitiesController.spec.ts
+++ b/runtime/backend/tests/unit/users/routes/ActivitiesController.spec.ts
@@ -18,6 +18,7 @@ import { JwtService } from "@nestjs/jwt";
 import { MockModel } from "../../../mocks/global";
 import { NetworkService } from "../../../../src/common/services/NetworkService";
 import { AccountsService } from "../../../../src/common/services/AccountsService";
+import { AccountSessionsService } from "../../../../src/common/services/AccountSessionsService";
 import { AuthService } from "../../../../src/common/services/AuthService";
 import { ChallengesService } from "../../../../src/common/services/ChallengesService";
 import { QueryService } from "../../../../src/common/services/QueryService";
@@ -38,6 +39,7 @@ describe("users/ActivitiesController", () => {
         AuthService, // requirement from ActivitiesService
         NetworkService, // requirement from AuthService
         AccountsService, // requirement from AuthService
+        AccountSessionsService, // requirement from AuthService
         ChallengesService, // requirement from AuthService
         JwtService, // requirement from AuthService
         QueryService, // requirement from AuthService
@@ -45,6 +47,10 @@ describe("users/ActivitiesController", () => {
         ActivitiesService, // requirement from ActivitiesController
         {
           provide: getModelToken("Account"),
+          useValue: MockModel,
+        }, // requirement from AuthService
+        {
+          provide: getModelToken("AccountSession"),
           useValue: MockModel,
         }, // requirement from AuthService
         {


### PR DESCRIPTION
**Commits:**
- [@dhealthdapps/backend] feat(common): create AccountSessionsSchema, AccountSessionDTO & update auth to store information in account-sessions collection instead
- [@dhealthdapps/backend] test(common): update tests for authentication collection switch from accounts to account-sessions

**Changes:**
- Create `AccountSessions` module in `common` scope & store data in `account-sessions`.
- Unique identifier will be:
  - address
  - sub
- Update `sub` to be extracted from authentication requests.
- Update `Auth` controller, service & strategies to query and store authentication information in `account-sessions` collection.
- Update `AccessTokenRequest` to contain `sub`.

**Testing:**
- `account-sessions` collection was correctly created and contains correct document information.
- Sub is correctly stored inside `account-sessions`.
- `account-sessions` was successfully queried to get sessions from `address` and `sub`.
- For each successful `/auth/token` request, there's a new session created in `account-sessions` collection.
- For each successful `/auth/refresh` request, the refresh token will be generated from the matched `account-sessions` document.
