### PR TITLE
Son/techn 350 allow multiple registries in

### DIFF
--- a/runtime/backend/src/common/requests/AccessTokenRequest.ts
+++ b/runtime/backend/src/common/requests/AccessTokenRequest.ts
@@ -72,4 +72,18 @@ export class AccessTokenRequest {
       "The JWT sub value that can be attached in the **bearer authorization header** of HTTP requests to serve as a unique identity of each device.",
   })
   public sub: string;
+
+  /**
+   * The registry address that has the incoming authentication
+   * transaction which included the challenge.
+   *
+   * @access public
+   * @var {string}
+   */
+  @ApiProperty({
+    example: "NBLT42KCICXZE2Q7Q4SWW3GWWE3XWPH3KUBBOEY",
+    description:
+      "The registry address that has the incoming authentication transaction which included the challenge.",
+  })
+  public registry: string;
 }

--- a/runtime/backend/src/common/routes/AuthController.ts
+++ b/runtime/backend/src/common/routes/AuthController.ts
@@ -164,7 +164,6 @@ export class AuthController {
    * to instruct *nest* to pass on the response cookie onto the
    * express `Response` object.
    *
-   * @todo Should accept an authorized registry in the /auth/challenge request
    * @method GET
    * @access protected
    * @async

--- a/runtime/backend/tests/unit/common/services/AuthService.spec.ts
+++ b/runtime/backend/tests/unit/common/services/AuthService.spec.ts
@@ -354,7 +354,7 @@ describe("common/AuthService", () => {
   describe("getTransactionQuery()", () => {
     it("should return correct result", () => {
       // prepare
-      const configServiceGetCall = jest.fn().mockReturnValue({});
+      const configServiceGetCall = jest.fn().mockReturnValue(["test-registry"]);
       (authService as any).configService = {
         get: configServiceGetCall,
       }
@@ -372,7 +372,7 @@ describe("common/AuthService", () => {
       };
 
       // act
-      const result = (authService as any).getTransactionQuery();
+      const result = (authService as any).getTransactionQuery("test-registry");
 
       // assert
       expect(configServiceGetCall).toHaveBeenCalledTimes(1);
@@ -410,7 +410,10 @@ describe("common/AuthService", () => {
       (authService as any).cookie = { name: "ELEVATE" };
 
       // act
-      const result = await (authService as any).findRecentChallenge("test-challenge");
+      const result = await (authService as any).findRecentChallenge(
+        "test-registry",
+        "test-challenge",
+      );
 
       // assert
       expect(getTransactionQueryCall).toHaveBeenCalledTimes(1);
@@ -427,7 +430,7 @@ describe("common/AuthService", () => {
       };
       const getTransactionQueryCall = jest
         .spyOn((authService as any), "getTransactionQuery")
-        .mockReturnValue({});
+        .mockReturnValue([]);
       const networkServiceDelegatePromisesCall = jest.fn().mockResolvedValue([
         { data: [{}] },
       ]);
@@ -438,7 +441,10 @@ describe("common/AuthService", () => {
       factoryCreatedContract.signature = "elevate:referral";
 
       // act
-      const result = await (authService as any).findRecentChallenge("test-challenge");
+      const result = await (authService as any).findRecentChallenge(
+        "test-registry",
+        "test-challenge",
+      );
 
       // assert
       expect(getTransactionQueryCall).toHaveBeenCalledTimes(1);
@@ -455,7 +461,7 @@ describe("common/AuthService", () => {
       };
       const getTransactionQueryCall = jest
         .spyOn((authService as any), "getTransactionQuery")
-        .mockReturnValue({});
+        .mockReturnValue([]);
       const networkServiceDelegatePromisesCall = jest.fn().mockResolvedValue([
         { data: [{}] },
       ]);
@@ -469,7 +475,10 @@ describe("common/AuthService", () => {
       Factory.createFromTransaction = factoryCreateFromTransactionCall;
 
       // act
-      const result = await (authService as any).findRecentChallenge("test-challenge");
+      const result = await (authService as any).findRecentChallenge(
+        "test-registry",
+        "test-challenge",
+      );
 
       // assert
       expect(getTransactionQueryCall).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
- [@dhealthdapps/backend] refactor(common): allow multiple registries in authentication
- [@dhealthdapps/backend] refactor(common): remove related @todo task