### PR TITLE
[@dhealthdapps/backend] refactor: define class AbstractAppModule and use in other modules

### DIFF
--- a/runtime/backend/src/AppConfiguration.ts
+++ b/runtime/backend/src/AppConfiguration.ts
@@ -18,6 +18,7 @@ import SMTPTransport from "nodemailer/lib/smtp-transport";
 
 // internal dependencies
 import { ConfigurationError } from "./common/errors/ConfigurationError";
+import { AppDatabaseModule } from "./common/modules/AppDatabaseModule";
 
 // configuration models
 // common scope
@@ -83,9 +84,9 @@ export class AppConfiguration {
    *
    * @access private
    * @static
-   * @var {MongooseModule}
+   * @var {AppDatabaseModule}
    */
-  private static DATABASE: MongooseModule;
+  private static DATABASE: AppDatabaseModule;
 
   /**
    * The dApp event emitter module using {@link EventEmitterModule} from nestjs.
@@ -339,7 +340,7 @@ export class AppConfiguration {
    * @static
    * @returns   {MongooseModule}    A `@nestjs/mongoose` MongooseModule object.
    */
-  public static getDatabaseModule(): MongooseModule {
+  public static getDatabaseModule(): AppDatabaseModule {
     // singleton instance for database
     if (undefined === AppConfiguration.DATABASE) {
       AppConfiguration.DATABASE = MongooseModule.forRoot(

--- a/runtime/backend/src/AppModule.ts
+++ b/runtime/backend/src/AppModule.ts
@@ -20,6 +20,7 @@ import { ScopeFactory } from "./common/ScopeFactory";
 import { DappConfig } from "./common/models/DappConfig";
 import { AppConfiguration } from "./AppConfiguration";
 import { LogService } from "./common/services/LogService";
+import { AbstractAppModule } from "./common/modules/AbstractAppModule";
 
 // configuration resources
 import dappConfigLoader from "../config/dapp";
@@ -42,7 +43,7 @@ import dappConfigLoader from "../config/dapp";
 @Module({
   imports: [AccountsModule, AuthModule, ChallengesModule],
 })
-export class AppModule {
+export class AppModule extends AbstractAppModule {
   /**
    * {@link LogService} instance for this class.
    *
@@ -67,9 +68,9 @@ export class AppModule {
    * @access public
    * @static
    * @param   {DappConfig}     configs   imported config
-   * @returns {DynamicModule} instance of this module
+   * @returns {AbstractAppModule} instance of this module
    */
-  public static register(configs: DappConfig): DynamicModule {
+  public static register(configs: DappConfig): AbstractAppModule {
     // print activation information of all scopes
     AppModule.logger.log(
       `Enabled scopes: ${JSON.stringify(configs.scopes, undefined, 2)}`,
@@ -82,7 +83,7 @@ export class AppModule {
       imports: modules,
       controllers: [AppController],
       providers: [AppService],
-    } as DynamicModule;
+    } as AbstractAppModule;
   }
 
   /**

--- a/runtime/backend/src/common/ScopeFactory.ts
+++ b/runtime/backend/src/common/ScopeFactory.ts
@@ -17,6 +17,7 @@ import { DappConfig } from "./models/DappConfig";
 import { Scopes } from "./Scopes";
 import { Schedulers } from "./Schedulers";
 import { AppConfiguration } from "../AppConfiguration";
+import { AbstractAppModule } from "./modules/AbstractAppModule";
 
 /**
  * @label COMMON
@@ -50,9 +51,9 @@ export class ScopeFactory {
    * processes: scoped modules and scheduler modules.
    *
    * @access private
-   * @var {DynamicModule[]}
+   * @var {AbstractAppModule[]}
    */
-  private baseImports: DynamicModule[] = [];
+  private baseImports: AbstractAppModule[] = [];
 
   /**
    * Constructs an imports factory around a {@link DappConfig} configuration
@@ -102,7 +103,7 @@ export class ScopeFactory {
   }
 
   /**
-   * Returns an array of nest `DynamicModule` that are enabled
+   * Returns an array of nest `AbstractAppModule` that are enabled
    * (opt-in) through the dApp configuration with the field
    * named `scopes` (config/dapp.json).
    * <br /><br />
@@ -114,9 +115,9 @@ export class ScopeFactory {
    * modules.
    *
    * @static
-   * @returns {DynamicModule[]}   A list of dynamic modules that are *enabled* as modules.
+   * @returns {AbstractAppModule[]}   A list of dynamic modules that are *enabled* as modules.
    */
-  public getModules(): DynamicModule[] {
+  public getModules(): AbstractAppModule[] {
     // reads *enabled* scopes (opt-in)
     const scopes: Scope[] = this.dappConfig.scopes;
 
@@ -129,7 +130,7 @@ export class ScopeFactory {
   }
 
   /**
-   * Returns an array of nest `DynamicModule` that are enabled
+   * Returns an array of nest `AbstractAppModule` that are enabled
    * (opt-in) through the dApp configuration with the field
    * named `scopes` (config/dapp.json). This method returns all
    * **cronjobs** (schedulers / commands) that must be registered
@@ -144,9 +145,9 @@ export class ScopeFactory {
    * modules.
    *
    * @static
-   * @returns {DynamicModule[]}   A list of dynamic modules that are *enabled* as schedulers.
+   * @returns {AbstractAppModule[]}   A list of dynamic modules that are *enabled* as schedulers.
    */
-  public getSchedulers(): DynamicModule[] {
+  public getSchedulers(): AbstractAppModule[] {
     // reads *enabled* scopes (opt-in)
     const scopes: Scope[] = this.dappConfig.scopes;
 

--- a/runtime/backend/src/common/Scopes.ts
+++ b/runtime/backend/src/common/Scopes.ts
@@ -16,6 +16,7 @@ import { NotifierModule } from "../notifier/NotifierModule";
 import { OAuthModule } from "../oauth/OAuthModule";
 import { AppConfiguration } from "../AppConfiguration";
 import { UsersModule } from "../users/UsersModule";
+import { AbstractAppModule } from "./modules/AbstractAppModule";
 
 /**
  * @label COMMON
@@ -47,10 +48,9 @@ import { UsersModule } from "../users/UsersModule";
  *
  * @var {[key: string]: KnownScopeModules}
  *
- * @todo define class `AbstractAppModule` and use in `DiscoveryModule`, `PayoutModule`, etc.
  * @since v0.1.0
  */
-export const Scopes: { [key: string]: any } = {
+export const Scopes: { [key: string]: AbstractAppModule } = {
   database: AppConfiguration.getDatabaseModule(),
   discovery: DiscoveryModule,
   payout: PayoutModule,

--- a/runtime/backend/src/common/Scopes.ts
+++ b/runtime/backend/src/common/Scopes.ts
@@ -41,13 +41,12 @@ import { AbstractAppModule } from "./modules/AbstractAppModule";
  * | `oauth` | {@link OAuthModule} | A oauth scope that consists in enabling OAuth data providers (e.g. Strava) and web hooks capabilities. |
  * | `users` | {@link UsersModule} | A user scope that consists in defining specific user profile information such as Activities data for Strava. |
  * <br /><br />
- * A `scheduler` scope is also included with {@link SchedulerModule} but
+ * A `scheduler` scope is also included with {@link WorkerModule} but
  * this one executes in a *parallel* process and thereby should not be
  * imported here.
  * <br /<br />
  *
- * @var {[key: string]: KnownScopeModules}
- *
+ * @var {[key: string]: AbstractAppModule}
  * @since v0.1.0
  */
 export const Scopes: { [key: string]: AbstractAppModule } = {

--- a/runtime/backend/src/common/modules/AbstractAppModule.ts
+++ b/runtime/backend/src/common/modules/AbstractAppModule.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is part of dHealth dApps Framework shared under LGPL-3.0
+ * Copyright (C) 2022-present dHealth Network, All rights reserved.
+ *
+ * @package     dHealth dApps Framework
+ * @subpackage  Backend
+ * @author      dHealth Network <devs@dhealth.foundation>
+ * @license     LGPL-3.0
+ */
+// external dependencies
+import { ModuleMetadata } from "@nestjs/common";
+
+/**
+ * @label COMMON
+ * @class AbstractAppModule
+ * @description The main definition for the AbstractAppModule module.
+ * @see https://github.com/nestjs/nest/blob/master/packages/common/interfaces/modules/module-metadata.interface.ts
+ *
+ * @abstract
+ * @since v0.5.6
+ */
+export abstract class AbstractAppModule implements ModuleMetadata {}

--- a/runtime/backend/src/common/modules/AppDatabaseModule.ts
+++ b/runtime/backend/src/common/modules/AppDatabaseModule.ts
@@ -1,0 +1,25 @@
+/**
+ * This file is part of dHealth dApps Framework shared under LGPL-3.0
+ * Copyright (C) 2022-present dHealth Network, All rights reserved.
+ *
+ * @package     dHealth dApps Framework
+ * @subpackage  Backend
+ * @author      dHealth Network <devs@dhealth.foundation>
+ * @license     LGPL-3.0
+ */
+// external dependencies
+import { MongooseModule } from "@nestjs/mongoose";
+
+// internal dependencies
+import { AbstractAppModule } from "./AbstractAppModule";
+
+/**
+ * @label COMMON
+ * @class AppDatabaseModule
+ * @description The main definition for the AppDatabaseModule module.
+ *
+ * @since v0.5.6
+ */
+export class AppDatabaseModule
+  extends MongooseModule
+  implements AbstractAppModule {}

--- a/runtime/backend/src/discovery/DiscoveryModule.ts
+++ b/runtime/backend/src/discovery/DiscoveryModule.ts
@@ -11,6 +11,10 @@
 import { Module } from "@nestjs/common";
 
 // internal dependencies
+// common scope
+import { AbstractAppModule } from "../common/modules/AbstractAppModule";
+
+// discovery scope
 import { DiscoveryAccountsModule } from "./modules/DiscoveryAccountsModule";
 import { AssetsModule } from "./modules/AssetsModule";
 import { TransactionsModule } from "./modules/TransactionsModule";
@@ -49,4 +53,4 @@ import { BlocksModule } from "./modules/BlocksModule";
     BlocksModule,
   ],
 })
-export class DiscoveryModule {}
+export class DiscoveryModule extends AbstractAppModule {}

--- a/runtime/backend/src/notifier/NotifierModule.ts
+++ b/runtime/backend/src/notifier/NotifierModule.ts
@@ -11,6 +11,10 @@
 import { Module } from "@nestjs/common";
 
 // internal dependencies
+// common scope
+import { AbstractAppModule } from "../common/modules/AbstractAppModule";
+
+// notifier scope
 import { EmailNotifierModule } from "./modules/EmailNotifierModule";
 import { NotifierFactoryModule } from "./modules/NotifierFactoryModule";
 import { AlertsModule } from "./modules/AlertsModule";
@@ -42,4 +46,4 @@ import { AlertsModule } from "./modules/AlertsModule";
     AlertsModule,
   ],
 })
-export class NotifierModule {}
+export class NotifierModule extends AbstractAppModule {}

--- a/runtime/backend/src/oauth/OAuthModule.ts
+++ b/runtime/backend/src/oauth/OAuthModule.ts
@@ -13,6 +13,7 @@ import { MongooseModule } from "@nestjs/mongoose";
 
 // internal dependencies
 // common scope
+import { AbstractAppModule } from "../common/modules/AbstractAppModule";
 import { AuthModule } from "../common/modules/AuthModule";
 import {
   AccountIntegration,
@@ -69,4 +70,4 @@ import { WebHooksModule } from "./modules";
   providers: [OAuthService],
   exports: [OAuthService],
 })
-export class OAuthModule {}
+export class OAuthModule extends AbstractAppModule {}

--- a/runtime/backend/src/payout/PayoutModule.ts
+++ b/runtime/backend/src/payout/PayoutModule.ts
@@ -11,6 +11,7 @@
 import { Module } from "@nestjs/common";
 
 // internal dependencies
+import { AbstractAppModule } from "../common/modules/AbstractAppModule";
 import { PayoutsModule } from "./modules/PayoutsModule";
 
 /**
@@ -65,4 +66,4 @@ import { PayoutsModule } from "./modules/PayoutsModule";
     PayoutsModule,
   ],
 })
-export class PayoutModule {}
+export class PayoutModule extends AbstractAppModule {}

--- a/runtime/backend/src/processor/ProcessorModule.ts
+++ b/runtime/backend/src/processor/ProcessorModule.ts
@@ -11,6 +11,7 @@
 import { Module } from "@nestjs/common";
 
 // internal dependencies
+import { AbstractAppModule } from "../common/modules/AbstractAppModule";
 import { OperationsModule } from "./modules/OperationsModule";
 
 /**
@@ -41,4 +42,4 @@ import { OperationsModule } from "./modules/OperationsModule";
     OperationsModule,
   ],
 })
-export class ProcessorModule {}
+export class ProcessorModule extends AbstractAppModule {}

--- a/runtime/backend/src/statistics/StatisticsModule.ts
+++ b/runtime/backend/src/statistics/StatisticsModule.ts
@@ -12,6 +12,7 @@ import { Module } from "@nestjs/common";
 
 // internal dependencies
 // statistics scope
+import { AbstractAppModule } from "../common/modules/AbstractAppModule";
 import { StatisticsImplementationModule } from "./modules/StatisticsImplementationModule";
 
 /**
@@ -50,4 +51,4 @@ import { StatisticsImplementationModule } from "./modules/StatisticsImplementati
     StatisticsImplementationModule,
   ],
 })
-export class StatisticsModule {}
+export class StatisticsModule extends AbstractAppModule {}

--- a/runtime/backend/src/users/UsersModule.ts
+++ b/runtime/backend/src/users/UsersModule.ts
@@ -11,6 +11,7 @@
 import { Module } from "@nestjs/common";
 
 // internal dependencies
+import { AbstractAppModule } from "../common/modules/AbstractAppModule";
 import { ActivitiesModule } from "./modules/ActivitiesModule";
 
 /**
@@ -36,4 +37,4 @@ import { ActivitiesModule } from "./modules/ActivitiesModule";
     ActivitiesModule,
   ],
 })
-export class UsersModule {}
+export class UsersModule extends AbstractAppModule {}

--- a/runtime/backend/src/worker/WorkerModule.ts
+++ b/runtime/backend/src/worker/WorkerModule.ts
@@ -16,6 +16,7 @@ import { ScopeFactory } from "../common/ScopeFactory";
 import { Schedulers } from "../common/Schedulers";
 import { LogService } from "../common/services/LogService";
 import { AppConfiguration } from "../AppConfiguration";
+import { AbstractAppModule } from "../common/modules/AbstractAppModule";
 
 /**
  * @label SCOPES
@@ -26,7 +27,7 @@ import { AppConfiguration } from "../AppConfiguration";
  * @since v0.1.0
  */
 @Module({})
-export class WorkerModule {
+export class WorkerModule extends AbstractAppModule {
   /**
    * {@link LogService} instance of this class.
    *
@@ -44,9 +45,9 @@ export class WorkerModule {
    *
    * @static
    * @param   {DappConfig}     configs   imported config
-   * @returns {DynamicModule} instance of this module
+   * @returns {AbstractAppModule} instance of this module
    */
-  static register(configs: DappConfig): DynamicModule {
+  static register(configs: DappConfig): AbstractAppModule {
     // filters out scopes that do not have schedulers registered
     // the `database` scope is ignored due to lack of schedulers
     const actualScopes = configs.scopes.filter(
@@ -64,7 +65,7 @@ export class WorkerModule {
     return {
       module: WorkerModule,
       imports: modules,
-    } as DynamicModule;
+    } as AbstractAppModule;
   }
 
   /**

--- a/runtime/backend/tests/unit/AppConfiguration.spec.ts
+++ b/runtime/backend/tests/unit/AppConfiguration.spec.ts
@@ -46,6 +46,7 @@ jest.mock("@nestjs-modules/mailer", () => {
 });
 
 // external dependencies
+
 import { Account, Address, PublicAccount } from "@dhealth/sdk";
 
 // internal dependencies
@@ -611,7 +612,7 @@ describe("AppConfiguration", () => {
     });
 
     it("should throw error given any missing mandatory configuration fields", () => {
-
+      // prepare
       const mandatoryFields: any = [
         { name: "defaultNode", value: undefined },
         { name: "defaultNode", value: {
@@ -761,6 +762,7 @@ describe("AppConfiguration", () => {
     });
 
     it("should throw error given any missing mandatory configuration fields", () => {
+      // prepare
       const mandatoryFields: any = [
         { name: "auth", value: undefined },
         { name: "auth", value: {

--- a/runtime/backend/tests/unit/oauth/routes/OAuthController.spec.ts
+++ b/runtime/backend/tests/unit/oauth/routes/OAuthController.spec.ts
@@ -258,4 +258,41 @@ describe("common/OAuthController", () => {
       });
     });
   });
+
+  describe("getProfile()", () => {
+    it("should call correct method and respond with DTO", async () => {
+      // prepare
+      (controller as any).authService = {
+        getAccount: jest.fn().mockReturnValue({
+          address: "fakeAddress",
+          firstTransactionAt: 0,
+          firstTransactionAtBlock: 0,
+          transactionsCount: 0,
+          referredBy: "fakeOtherAddress",
+          referralCode: "otherUser",
+        }),
+      };
+      (controller as any).oauthService = {
+        getIntegrations: jest.fn().mockReturnValue({
+          data: [
+            { name: "strava" }
+          ],
+        }),
+      };
+
+      // act
+      const profile = await (controller as any).getProfile({});
+
+      // assert
+      expect(profile).toStrictEqual({
+        address: "fakeAddress",
+        firstTransactionAt: 0,
+        firstTransactionAtBlock: 0,
+        integrations: ["strava"],
+        transactionsCount: 0,
+        referredBy: "fakeOtherAddress",
+        referralCode: "otherUser",
+      });
+    });
+  });
 });

--- a/runtime/backend/tests/unit/payout/schedulers/BroadcastActivityPayouts.spec.ts
+++ b/runtime/backend/tests/unit/payout/schedulers/BroadcastActivityPayouts.spec.ts
@@ -851,4 +851,33 @@ describe("payout/BroadcastActivityPayouts", () => {
       );
     });
   });
+
+  describe("runAsScheduler()", () => {
+    it("should call correct methods and run correctly", async () => {
+      // prepare
+      const loggerSetModuleCall = jest
+        .spyOn(logger, "setModule")
+        .mockReturnValue(logger);
+      const debugLogCall = jest
+        .spyOn((command as any), "debugLog")
+        .mockReturnValue(true);
+      const runCall = jest
+        .spyOn(command, "run")
+        .mockResolvedValue();
+
+      // act
+      await command.runAsScheduler();
+
+      // assert
+      expect(loggerSetModuleCall).toHaveBeenNthCalledWith(1, "payout/BroadcastActivityPayouts");
+      expect(debugLogCall).toHaveBeenNthCalledWith(1, `Starting payout broadcast for subjects type: activities`);
+      expect(runCall).toHaveBeenNthCalledWith(
+        1,
+        ["activities"], {
+          maxCount: 3, // <-- MAXIMUM 3 BROADCASTS per round
+          debug: true,
+        } as BroadcastActivityPayoutsCommandOptions
+      );
+    });
+  });
 });

--- a/runtime/backend/tests/unit/payout/schedulers/PrepareActivityPayouts.spec.ts
+++ b/runtime/backend/tests/unit/payout/schedulers/PrepareActivityPayouts.spec.ts
@@ -764,4 +764,34 @@ describe("payout/PrepareActivityPayouts", () => {
       );
     });
   });
+
+  describe("runAsScheduler()", () => {
+    it("should call correct methods and run correctly", async () => {
+      // prepare
+      const loggerSetModuleCall = jest
+        .spyOn(logger, "setModule")
+        .mockReturnValue(logger);
+      const debugLogCall = jest
+        .spyOn((command as any), "debugLog")
+        .mockReturnValue(true);
+      const runCall = jest
+        .spyOn(command, "run")
+        .mockResolvedValue();
+
+      // act
+      await command.runAsScheduler();
+
+      // assert
+      expect(loggerSetModuleCall).toHaveBeenNthCalledWith(1, "payout/PrepareActivityPayouts");
+      expect(debugLogCall).toHaveBeenNthCalledWith(1, `Starting payout preparation for subjects type: activities`);
+      expect(debugLogCall).toHaveBeenNthCalledWith(2, `Total number of payouts prepared: "0"`);
+      expect(runCall).toHaveBeenNthCalledWith(
+        1,
+        ["activities"],
+        {
+          debug: true,
+        } as PayoutCommandOptions
+      );
+    });
+  });
 });

--- a/runtime/backend/tests/unit/statistics/schedulers/UserAggregation.spec.ts
+++ b/runtime/backend/tests/unit/statistics/schedulers/UserAggregation.spec.ts
@@ -369,6 +369,19 @@ describe("statistics/UserAggregation", () => {
     });
   });
 
+  describe("getNextPeriod()", () => {
+    it("should return correct result", () => {
+      // prepare
+      const date = new Date(Date.UTC(2022, 1, 1, 10, 10, 10, 10)); // 01/02/2022 at 10:10:10:010
+
+      // act
+      const result = (service as any).getNextPeriod(date);
+
+      // assert
+      expect(result).toBe("20220201");
+    });
+  });
+
   describe("createAggregationQuery()", () => {
     it("should return correct database aggregate query", () => {
       // act


### PR DESCRIPTION
This is for @todo task:
- @todo define class `AbstractAppModule` and use in `DiscoveryModule`, `PayoutModule`, etc. at line 49 of Scopes.ts

Commits:
- [@dhealthdapps/backend] refactor: define class AbstractAppModule and use in other modules
