### PR TITLE
Son/techn 371 fix todo tasks discovery scope

### DIFF
--- a/runtime/backend/src/discovery/models/AccountDiscoveryStateData.ts
+++ b/runtime/backend/src/discovery/models/AccountDiscoveryStateData.ts
@@ -25,6 +25,18 @@ import type { StateData } from "../../common/models/StateData";
  */
 export class AccountDiscoveryStateData implements StateData {
   /**
+   * Contains the *address* of the last account that was used
+   * in the *transaction* discovery. This is used in the case
+   * of runtime configuration that contains **more than one**
+   * discovery source and permits to track multiple accounts
+   * sequentially.
+   *
+   * @access public
+   * @var {string}
+   */
+  public lastUsedAccount: string;
+
+  /**
    * Contains the last page number that was used in the
    * transactions database query. Since accounts are all
    * discovery from transactions, we only need to read a

--- a/runtime/backend/src/discovery/models/AssetSchema.ts
+++ b/runtime/backend/src/discovery/models/AssetSchema.ts
@@ -27,7 +27,6 @@ import { AssetDTO } from "./AssetDTO";
  * Note that this class uses the generic {@link Transferable} trait to
  * enable a `toDTO()` method on the model.
  *
- * @todo The {@link Asset} model does not need fields to be **public**.
  * @todo Timestamp fields should be **numbers** to avoid timezone issues.
  * @since v0.3.0
  */

--- a/runtime/backend/src/discovery/models/BlockSchema.ts
+++ b/runtime/backend/src/discovery/models/BlockSchema.ts
@@ -27,7 +27,6 @@ import { BlockDTO } from "./BlockDTO";
  * Note that this class uses the generic {@link Transferable} trait to
  * enable a `toDTO()` method on the model.
  *
- * @todo The {@link Asset} model does not need fields to be **public**.
  * @todo Timestamp fields should be **numbers** to avoid timezone issues.
  * @since v0.3.2
  */

--- a/runtime/backend/src/discovery/schedulers/DiscoverAssets/DiscoverAssets.ts
+++ b/runtime/backend/src/discovery/schedulers/DiscoverAssets/DiscoverAssets.ts
@@ -190,7 +190,6 @@ export class DiscoverAssets extends DiscoveryCommand {
    * <br /><br />
    * This scheduler is registered to run **every 2 minutes**.
    *
-   * @todo This discovery should use a specific **discovery** config field instead of dappPublicKey
    * @see BaseCommand
    * @access public
    * @async

--- a/runtime/backend/src/discovery/schedulers/DiscoverTransactions/DiscoverTransactions.ts
+++ b/runtime/backend/src/discovery/schedulers/DiscoverTransactions/DiscoverTransactions.ts
@@ -92,7 +92,6 @@ export interface DiscoverTransactionsCommandOptions
  * scheduler. Contains source code for the execution logic of a
  * command with name: `discovery:DiscoverTransactions`.
  *
- * @todo Should use `BigInt` in {@link extractTransactionBlock} because `height.compact()` is not protected for number overflow.
  * @since v0.2.0
  */
 @Injectable()
@@ -332,10 +331,9 @@ export class DiscoverTransactions extends DiscoveryCommand {
 
     // executes the actual command logic (this will call discover())
     // additionally, updates state.data.lastUsedAccount
-    // @todo remove debug flag for staging/production releases
     await this.run(["both"], {
       source,
-      debug: false,
+      debug: process.env.NODE_ENV === "development",
     } as DiscoveryCommandOptions);
   }
 
@@ -736,7 +734,6 @@ export class DiscoverTransactions extends DiscoveryCommand {
    * The transaction header can always be re-created using the other fields
    * present in the {@link Transaction} document.
    *
-   * @todo Move to a bytes-optimized storage format for payloads (only message is necessary)
    * @param {Transaction} transaction
    * @returns {string}
    */

--- a/runtime/backend/tests/unit/discovery/schedulers/DiscoverAccounts.spec.ts
+++ b/runtime/backend/tests/unit/discovery/schedulers/DiscoverAccounts.spec.ts
@@ -193,21 +193,23 @@ describe("discovery/DiscoverAccounts", () => {
         .mockReturnValue({
           address: { plain: () => "NDAPPH6ZGD4D6LBWFLGFZUT2KQ5OLBLU32K3HNY" }
         } as any);
+      jest
+        .spyOn((service as any), "getNextSource")
+        .mockResolvedValue("test-source");
 
       // act
       await service.runAsScheduler();
 
       // assert
-      expect(configServiceGetCall).toHaveBeenCalledTimes(2);
-      expect(configServiceGetCall).toHaveBeenCalledWith("dappPublicKey");
-      expect(configServiceGetCall).toHaveBeenCalledWith("network.networkIdentifier");
+      expect(configServiceGetCall).toHaveBeenCalledTimes(1);
+      expect(configServiceGetCall).toHaveBeenCalledWith("discovery.sources");
       expect((service as any).lastExecutedAt).toBe(1643673600000);
       expect(superRun).toHaveBeenNthCalledWith(
         1,
         [],
         {
-          source: "NDAPPH6ZGD4D6LBWFLGFZUT2KQ5OLBLU32K3HNY",
-          debug: false,
+          source: "test-source",
+          debug: true,
         }
       );
     });
@@ -258,8 +260,10 @@ describe("discovery/DiscoverAccounts", () => {
       // prepare
       const transactionsServiceFindCall = jest.spyOn(transactionsService, "find").mockResolvedValueOnce({
         data: fakeCreateTransactionDocuments(100), // full page ONCE
+        isLastPage: () => false,
       } as PaginatedResultDTO<TransactionDocument>).mockResolvedValueOnce({
         data: [], // empty page
+        isLastPage: () => true,
       } as PaginatedResultDTO<TransactionDocument>);
 
       // act
@@ -294,8 +298,10 @@ describe("discovery/DiscoverAccounts", () => {
       // prepare
       const transactionsServiceFindCall = jest.spyOn(transactionsService, "find").mockResolvedValueOnce({
         data: fakeCreateTransactionDocuments(100), // full page ONCE
+        isLastPage: () => false,
       } as PaginatedResultDTO<TransactionDocument>).mockResolvedValueOnce({
         data: fakeCreateTransactionDocuments(20), // not full
+        isLastPage: () => false,
       } as PaginatedResultDTO<TransactionDocument>);
 
       // act
@@ -330,6 +336,7 @@ describe("discovery/DiscoverAccounts", () => {
       // prepare
       const transactionsServiceFindCall = jest.spyOn(transactionsService, "find").mockResolvedValueOnce({
         data: fakeCreateTransactionDocuments(100), // full page
+        isLastPage: () => false,
       } as PaginatedResultDTO<TransactionDocument>);
 
       // act
@@ -405,6 +412,7 @@ describe("discovery/DiscoverAccounts", () => {
       .spyOn(transactionsService, "find")
         .mockResolvedValue({
           data: fakeCreateTransactionDocuments(3), // page is not full
+          isLastPage: () => false,
         } as PaginatedResultDTO<TransactionDocument>);
 
       // act
@@ -517,7 +525,8 @@ describe("discovery/DiscoverAccounts", () => {
         .fn()
         .mockResolvedValue({
           data: fakeCreateTransactionDocuments(3), // page is not full
-        });
+          isLastPage: () => false,
+        } as PaginatedResultDTO<TransactionDocument>);
       (service as any).transactionsService.find = transactionsServiceFindCall;
 
       // act


### PR DESCRIPTION
- [@dhealthdapps/backend] refactor(discovery): update discoverAccounts scheduler to query from configurable sources instead of main app's public key
- [@dhealthdapps/backend] refactor(discovery): update debug option value of discoverTransactions scheduler to be false if app is in staging/production environment
- [@dhealthdapps/backend] refactor(discovery): remove obsolete todo tasks