### PR TITLE
[@dhealthdapps/backend] refactor: change /me route name to /profile in AppController.ts

### DIFF
--- a/runtime/backend/src/AppController.ts
+++ b/runtime/backend/src/AppController.ts
@@ -117,7 +117,7 @@ export class AppController {
    * @returns Promise<AccountDTO>       An authenticated user's profile information ("account" information).
    */
   @UseGuards(AuthGuard)
-  @Get("me")
+  @Get("profile")
   @ApiOperation({
     summary: "Get an authenticated user's profile details",
     description:


### PR DESCRIPTION
Issue:
•   `/me` route in oauth scope does not override `/me` route in `AppController.ts`
•   Leading to frontend cannot get integration details (even with `oauth` scope enabled).
•   This results in the Strava panel keeps displaying even when user logged in successfully.

Solution:
•   Update /me route in `AppController.ts` to be `/profile`
•   Frontend, when need to get account information without integration can call `/profile`
•   Frontend, when need to get account information with integration can call `/me`